### PR TITLE
WIP: Fluent Validation Plugin

### DIFF
--- a/plugins/Validation/src/Validation.ts
+++ b/plugins/Validation/src/Validation.ts
@@ -284,7 +284,7 @@ export function Validation<T>(input: State<T>) {
     }
 
     return {
-        valid(fields?: any[]): boolean {
+        valid(fields?: (keyof T)[]): boolean {
             return this.errors(fields).length === 0;
         },
         required(): boolean {

--- a/plugins/Validation/src/Validation.ts
+++ b/plugins/Validation/src/Validation.ts
@@ -38,8 +38,6 @@ type ObjectValidator<Root, T> = ObjectNestedValidator<Root, T> & ObjectRootValid
 
 type ArrayValidator<Root, T> = ObjectValidator<Root, T> & {
     validate(validator: ValidateFn<T[]>, message?: string): void;
-
-    forEach(fn: (validator: NestedValidator<Root, T>) => void): void;
 };
 
 interface Condition {
@@ -266,12 +264,6 @@ function buildProxy(
                         message,
                         conditions,
                     });
-                };
-            }
-
-            if (nestedProp === 'forEach') {
-                return (fn: (validator: any) => void) => {
-                    fn(buildProxy(instance, path, state, conditions.slice(0)));
                 };
             }
 

--- a/plugins/Validation/src/Validation.ts
+++ b/plugins/Validation/src/Validation.ts
@@ -1,259 +1,376 @@
+/* tslint:disable:no-any */
 import { Plugin, State } from '@hookstate/core';
-import {
-  Downgraded,
-  PluginCallbacks,
-  PluginCallbacksOnBatchArgument,
-  PluginCallbacksOnDestroyArgument,
-  PluginCallbacksOnSetArgument, useState,
-} from '@hookstate/core/dist';
+import { Downgraded, PluginCallbacks, useState, } from '@hookstate/core/dist';
 
 export const ValidationId = Symbol('Validation');
 
 type ValidateFn<T> = (value: T) => boolean;
 type Path = readonly (string | number | symbol)[];
 
-interface CommonValidator {
-  isValid(): boolean;
+interface CommonValidator<T> {
+    valid(): boolean;
+
+    required(message?: string): void;
+
+    isRequired(): boolean;
 }
 
-interface SingleValidator<T> extends CommonValidator {
-  validate: (validator: ValidateFn<T>, message?: string) => void;
+interface SingleValidator<T> extends CommonValidator<T> {
+    validate: (validator: ValidateFn<T>, message?: string) => void;
 }
 
-type NestedValidator<T> = T extends string ? SingleValidator<T> : T extends any[] ? ArrayValidator<T[0]> : ObjectValidator<T>;
+type NestedValidator<Root, T> = T extends string ? SingleValidator<T> :
+    T extends any[] ? ArrayValidator<Root, T[0]> : ObjectValidator<Root, T>;
 
-type ObjectValidator<T> = {
-  [Key in keyof T]: NestedValidator<T[Key]>
-} & CommonValidator;
+type ObjectValidator<Root, T> = {
+    [Key in keyof T]: NestedValidator<Root, T[Key]>
+} & CommonValidator<T> & {
+    valid(fields?: (keyof T)[]): boolean;
 
-type ArrayValidator<T> = CommonValidator & ObjectValidator<T> & {
-  validate(validator: ValidateFn<T[]>, message?: string): void;
-
-  forEach(fn: (validator: NestedValidator<T>) => void): void;
+    when(fn: (value: T, root: Root) => boolean): ObjectValidator<Root, T>;
 };
 
-interface Validator {
-  fn: ValidateFn<any>;
-  path: Path;
-  message?: string;
+type ArrayValidator<Root, T> = CommonValidator<T> & ObjectValidator<Root, T> & {
+    validate(validator: ValidateFn<T[]>, message?: string): void;
+
+    forEach(fn: (validator: NestedValidator<Root, T>) => void): void;
+};
+
+interface Condition {
+    fn: (value: any, root: any) => boolean;
+    state: State<any>;
+    path: Path;
 }
 
-type ReturnType<T> = ObjectValidator<T> | ArrayValidator<T> | SingleValidator<T>;
+interface Validator {
+    fn: ValidateFn<any>;
+    path: Path;
+    message?: string;
+    required?: boolean;
+    condition?: Condition;
+}
 
-class ValidatorInstance<T> implements PluginCallbacks {
-  validators: Validator[] = [];
+type ReturnType<Root, T> = ObjectValidator<Root, T> | ArrayValidator<Root, T> | SingleValidator<T>;
 
-  onBatchFinish(_: PluginCallbacksOnBatchArgument): void {
-  }
+class ValidatorInstance<T> {
+    validators: Validator[] = [];
 
-  onBatchStart(_: PluginCallbacksOnBatchArgument): void {
-  }
+    isRequired(state: State<T>, downgraded: State<T>) {
+        return this.matchValidators(state, downgraded).some(s => !!s.validator.required);
+    }
 
-  onDestroy(_: PluginCallbacksOnDestroyArgument): void {
-  }
+    valid(state: State<T>, downgraded: State<T>) {
+        const validators = this.matchValidators(state, downgraded);
 
-  onSet(_: PluginCallbacksOnSetArgument): void {
-  }
+        for (const { paths, validator } of validators) {
+            if (paths.length && isArrayState(state)) {
+                const allValid = state.every((item, index) => {
+                    if (validator.condition) {
+                        const value = downgraded[index].get();
+                        const root = validator.condition.state.get();
 
-  isValid(state: State<T>, downgraded: State<T>) {
-    for (const validator of this.validators) {
-      const paths = [...validator.path];
+                        if (!validator.condition.fn(value, root)) {
+                            return true;
+                        }
+                    }
 
-      let match = true;
+                    return this.validNested(paths, item, downgraded[index], validator);
+                });
 
-      for (const path of state.path) {
-        if (typeof path === 'string') {
-          if (paths.length === 0) {
-            break;
-          }
+                // if an array, run validation through each
+                if (!allValid) {
+                    return false;
+                }
+            } else {
+                if (validator.condition) {
+                    let target = validator.condition.state;
 
-          if (paths.shift() !== path) {
-            match = false;
-            break;
-          }
+                    // always skip first, they are the same as target state
+                    const statePaths = [...state.path.slice(1)];
+                    const conditionPaths = [...validator.condition.path.slice(1)];
 
-          //data = data.nested(path as keyof T);
-          //target = target.nested(path as keyof T);
-        } else if (typeof path === 'number') {
-          if (paths.length === 0) {
-            match = false;
+                    for (const path of statePaths) {
+                        if (typeof path === 'string') {
+                            if (conditionPaths.length === 0) {
+                                break;
+                            }
 
-            break;
-          }
+                            target = target.nested(path);
 
-          //const nextPath = paths.shift();
+                            conditionPaths.shift();
+                        } else if (typeof path === 'number') {
+                            target = target[path];
+                        }
+                    }
 
-          //data = data.nested(nextPath as keyof T);
-          //target = target.nested(nextPath as keyof T);
+                    if (!validator.condition.fn(target.get(), validator.condition.state.get())) {
+                        continue;
+                    }
+                }
+
+                if (!this.validNested(paths, state, downgraded, validator)) {
+                    return false;
+                }
+            }
         }
-      }
 
-      if (!match) {
-        continue;
-      }
+        return true;
+    }
 
-      if (paths.length && isArrayState(state)) {
-        // if an array, run validation through each
-        if (!state.every((item, index) => this.isValidNested(paths, item, downgraded[index], validator))) {
-          return false;
+    private matchValidators(state: State<any>, downgraded: State<T>) {
+        return this.validators.map(validator => {
+            const paths = [...validator.path];
+
+            let match = true;
+
+            for (const path of state.path) {
+                if (typeof path === 'string') {
+                    if (paths.length === 0) {
+                        break;
+                    }
+
+                    if (paths.shift() !== path) {
+                        match = false;
+                        break;
+                    }
+                } else if (typeof path === 'number') {
+                    if (paths.length === 0) {
+                        match = false;
+
+                        break;
+                    }
+                }
+            }
+
+            return {
+                paths,
+                match,
+                validator,
+            };
+        }).filter(v => !!v.match);
+    }
+
+    private validNested(paths: Path, state: State<any>, downgrade: State<any>, validator: Validator) {
+        let data: State<any> = downgrade;
+        let target: State<any> = state;
+
+        // drill down any unmatched paths
+        for (const path of paths) {
+            data = data.nested(path);
+            target = target.nested(path);
         }
-      } else if (!this.isValidNested(paths, state, downgraded, validator)) {
-        return false;
-      }
+
+        if (isPrimitiveState(target)) {
+            if (!validator.fn(target.get())) {
+                return false;
+            }
+        } else if (!validator.fn(data.get())) {
+            return false;
+        }
+
+        return true;
     }
-
-    return true;
-  }
-
-  private isValidNested<T>(paths: Path, state: State<T>, downgrade: State<T>, validator: Validator) {
-    let data: State<any> = downgrade;
-    let target: State<any> = state;
-
-    // drill down any unmatched paths
-    for (const path of paths) {
-      data = data.nested(path as keyof T);
-      target = target.nested(path as keyof T);
-    }
-
-    if (isPrimitiveState(target)) {
-      if (!validator.fn(target.get())) {
-        return false;
-      }
-    } else if (!validator.fn(data.get())) {
-      return false;
-    }
-
-    return true;
-  }
 }
 
 function isPrimitiveState<T>(state: any): state is State<T> {
-  return state.keys === undefined;
+    return state.keys === undefined;
 }
 
-function isObjectState<T>(state: any): state is State<T> {
-  return Array.isArray(state.keys) && state.keys.every(k => typeof k === 'string');
+function isObjectState<T>(state: State<T>, keys: any): keys is ReadonlyArray<keyof T> {
+    return Array.isArray(state.keys) && state.keys.length > 0 && state.keys.every(k => typeof k === 'string');
 }
 
 function isArrayState<T>(state: any): state is ReadonlyArray<State<T>> {
-  return !isPrimitiveState(state) && !isObjectState(state);
+    return !isPrimitiveState(state) && !isObjectState(state, state.keys);
 }
 
-function forEach(instance: ValidatorInstance<any>, state: State<any>, downgraded: State<any>, path?: (string | number | symbol)[]) {
-  const realPath = path || state.path;
-
-  return (fn: (validator: any) => void) => {
-    fn(
-      new Proxy({}, {
-        get(target, prop) {
-          const getter = (fieldValidator: ValidateFn<any>, message?: string) => {
-            instance.validators.push({
-              fn: fieldValidator,
-              path: [...realPath, prop],
-              message,
-            });
-          };
-
-          return new Proxy(getter, {
-            apply(t: (fieldValidator: ValidateFn<any>) => void, thisArg: any, argArray?: any): any {
-              t.apply(thisArg, argArray);
-            },
-            get(_, nestedProp) {
-              const nestedPath = [...realPath, prop];
-
-              if (nestedProp === 'isValid') {
-                return instance.isValid(state, downgraded);
-              }
-
-              if (nestedProp === 'validate') {
-                return (nestedValidator: ValidateFn<any>, message?: string) => {
-                  instance.validators.push({
-                    fn: nestedValidator,
-                    path: nestedPath,
-                    message,
-                  });
-                };
-              }
-
-              if (nestedProp === 'forEach') {
-                return forEach(instance, state, downgraded, nestedPath);
-              }
-
-              throw new Error(`Unsupported property.`);
-            },
-          });
+function buildInnerProxy(
+    target: any,
+    instance: ValidatorInstance<any>,
+    path: Path,
+    state: State<any>,
+    downgraded: State<any>,
+    condition?: Condition
+): any {
+    return new Proxy(target, {
+        apply(t: (fieldValidator: ValidateFn<any>) => void, thisArg: any, argArray?: any): any {
+            t.apply(thisArg, argArray);
         },
-      }),
-    );
-  };
+        get(_: any, nestedProp: PropertyKey, receiver: any) {
+            if (nestedProp === 'when') {
+                return (when: ValidateFn<any>) => {
+                    condition = {
+                        fn: when,
+                        state: downgraded,
+                        path,
+                    };
+
+                    return receiver;
+                };
+            }
+
+            if (nestedProp === 'isRequired') {
+                return instance.isRequired(state, downgraded);
+            }
+
+            if (nestedProp === 'required') {
+                return (message?: string) => {
+                    instance.validators.push({
+                        fn: (value => Array.isArray(value) ? value.length > 0 : !!value),
+                        path,
+                        required: true,
+                        message,
+                        condition,
+                    });
+                };
+            }
+
+            if (nestedProp === 'valid') {
+                return () => instance.valid(state, downgraded);
+            }
+
+            if (nestedProp === 'validate') {
+                return (nestedValidator: ValidateFn<any>, message?: string) => {
+                    instance.validators.push({
+                        fn: nestedValidator,
+                        path,
+                        message,
+                        condition,
+                    });
+                };
+            }
+
+            if (nestedProp === 'forEach') {
+                return forEach(instance, state, downgraded, path);
+            }
+
+            // user is chaining down properties
+            return buildInnerProxy(target, instance, [...path, nestedProp], state, downgraded, condition);
+        },
+    });
 }
 
-function stateToApi<T>(instance: ValidatorInstance<any>, state: State<any>, downgraded: State<any>): ReturnType<T> {
-  if (isPrimitiveState(state)) {
-    return {
-      validate: (fn: ValidateFn<any>, message?: string) => {
-        instance.validators.push({
-          fn,
-          path: state.path,
-          message,
-        });
-      },
-      isValid: () => instance.isValid(state, downgraded),
-    } as SingleValidator<any>;
-  }
+function buildProxy(instance: ValidatorInstance<any>, path: Path, state: State<any>, downgraded: State<any>) {
+    let condition: Condition;
 
-  if (isObjectState(state)) {
-    // object field type
-    const api = { isValid: () => instance.isValid(state, downgraded) } as ObjectValidator<T>;
+    return new Proxy({}, {
+        get(target: any, prop: PropertyKey, receiver: any) {
+            if (prop === 'when') {
+                return (when: ValidateFn<any>) => {
+                    condition = {
+                        fn: when,
+                        state: downgraded,
+                        path,
+                    };
 
-    for (const field of state.keys) {
-      api[field] = stateToApi(instance, state.nested(field), downgraded.nested(field));
+                    return receiver;
+                };
+            }
+
+            const getter = (fieldValidator: ValidateFn<any>, message?: string) => {
+                instance.validators.push({
+                    fn: fieldValidator,
+                    path: [...path, prop],
+                    message,
+                    condition,
+                });
+            };
+
+            return buildInnerProxy(getter, instance, path, state, downgraded, condition);
+        },
+    });
+}
+
+function forEach(instance: ValidatorInstance<any>, state: State<any>, downgraded: State<any>, path?: Path) {
+    return (fn: (validator: any) => void) => {
+        fn(buildProxy(instance, path || state.path, state, downgraded));
+    };
+}
+
+function stateToApi<T>(
+    instance: ValidatorInstance<any>,
+    state: State<any>,
+    downgraded: State<any>,
+    condition?: (value: T) => boolean
+): ReturnType<any, T> {
+    if (isPrimitiveState(state)) {
+        return {
+            validate: (fn: ValidateFn<any>, message?: string) => {
+                instance.validators.push({
+                    fn,
+                    path: state.path,
+                    message,
+                });
+            },
+            valid: () => instance.valid(state, downgraded),
+            isRequired: () => instance.isRequired(state, downgraded),
+            required(message?: string) {
+                instance.validators.push({
+                    fn: (value => Array.isArray(value) ? value.length > 0 : !!value),
+                    path: state.path,
+                    message,
+                    required: true,
+                });
+            },
+        } as SingleValidator<any>;
     }
 
-    return api;
-  }
+    if (isObjectState(state, state.keys)) {
+        // object field type
+        const api = {
+            valid: (fields: (keyof T)[]) => {
+                if (fields === undefined) {
+                    return instance.valid(state, downgraded);
+                }
 
-  // array field type
-  return {
-    isValid: () => instance.isValid(state, downgraded),
-    forEach: forEach(instance, state, downgraded),
-    validate(fn: (value: any, message?: string) => boolean, message: string | undefined): void {
-      instance.validators.push({
-        fn,
-        path: state.path,
-        message,
-      });
-    },
-  } as ArrayValidator<T>;
+                for (const field of fields) {
+                    return instance.valid(state.nested(field), downgraded.nested(field));
+                }
+
+                return true;
+            },
+            when(fn: (value: T) => boolean) {
+                return stateToApi<T>(instance, state, downgraded, fn);
+            },
+        } as ObjectValidator<any, T>;
+
+        for (const field of state.keys) {
+            api[field] = stateToApi(instance, state.nested(field), downgraded.nested(field));
+        }
+
+        return api;
+    }
+
+    return buildInnerProxy({}, instance, state.path, state, downgraded);
 }
 
 export function Validation(): Plugin;
 export function Validation(input: State<string>): SingleValidator<string>;
 export function Validation(input: State<number>): SingleValidator<number>;
-export function Validation<T>(input: State<T[]>): ArrayValidator<T>;
-export function Validation<T>(input: State<T>): ObjectValidator<T>;
-export function Validation<T>(input?: State<T>): Plugin | ReturnType<T> {
-  if (input === undefined) {
-    return {
-      id: ValidationId,
-      init: () => {
-        return new ValidatorInstance();
-      },
-    };
-  }
+export function Validation<T>(input: State<T[]>): ArrayValidator<T[], T>;
+export function Validation<T>(input: State<T>): ObjectValidator<T, T>;
+export function Validation<T>(input?: State<T>): Plugin | ReturnType<T, T> {
+    if (input === undefined) {
+        return {
+            id: ValidationId,
+            init: () => {
+                return new ValidatorInstance() as PluginCallbacks;
+            },
+        };
+    }
 
-  const [instance] = input.attach(ValidationId);
+    const [instance] = input.attach(ValidationId);
 
-  if (instance instanceof Error) {
-    throw new Error(`Forgot to run state.attach(Validation())`);
-  }
+    if (instance instanceof Error) {
+        throw new Error(`Forgot to run state.attach(Validation())`);
+    }
 
-  if (!(instance instanceof ValidatorInstance)) {
-    throw new Error('Expected plugin to be of ValidatorInstance');
-  }
+    if (!(instance instanceof ValidatorInstance)) {
+        throw new Error('Expected plugin to be of ValidatorInstance');
+    }
 
-  const downgraded: State<T> = useState(input);
-  downgraded.attach(Downgraded);
+    const downgraded: State<T> = useState(input);
+    downgraded.attach(Downgraded);
 
-  return stateToApi(instance, input, downgraded);
+    return stateToApi<T>(instance, input, downgraded);
 }

--- a/plugins/Validation/src/Validation.ts
+++ b/plugins/Validation/src/Validation.ts
@@ -1,38 +1,42 @@
 /* tslint:disable:no-any */
-import { Plugin, State } from '@hookstate/core';
-import { PluginCallbacks } from '@hookstate/core/dist';
+import { State } from '@hookstate/core';
+import { PluginCallbacks, StateValueAtRoot } from '@hookstate/core/dist';
 
 export const ValidationId = Symbol('Validation');
 
 type ValidateFn<T> = (value: T) => boolean;
 type Path = readonly (string | number | symbol)[];
 
-interface CommonValidator<T> {
-    valid(): boolean;
-
-    errors(): string[];
-
-    required(message?: string): void;
-
-    isRequired(): boolean;
+interface NestedState {
+    state: State<any>;
+    parent?: NestedState;
 }
 
-interface SingleValidator<T> extends CommonValidator<T> {
-    validate: (validator: ValidateFn<T>, message?: string) => void;
+interface SingleValidator<T> {
+    required(message?: string): void;
+
+    when(fn: (value: State<T>) => boolean): this;
+
+    validate(validator: ValidateFn<T>, message?: string): void;
 }
 
 type NestedValidator<Root, T> = T extends string ? SingleValidator<T> :
     T extends any[] ? ArrayValidator<Root, T[0]> : ObjectValidator<Root, T>;
 
-type ObjectValidator<Root, T> = {
+type ObjectNestedValidator<Root, T> = {
     [Key in keyof T]: NestedValidator<Root, T[Key]>
-} & CommonValidator<T> & {
-    valid(fields?: (keyof T)[]): boolean;
-
-    when(fn: (value: T, root: Root) => boolean): ObjectValidator<Root, T>;
 };
 
-type ArrayValidator<Root, T> = CommonValidator<T> & ObjectValidator<Root, T> & {
+interface ObjectRootValidator<Root, T> extends SingleValidator<T> {
+    when(fn: (value: State<T>, root: Root) => boolean): this;
+}
+
+type ObjectValidator<Root, T> = ObjectNestedValidator<Root, T> & ObjectRootValidator<Root, T> & {
+    whenType<K extends keyof T, V extends T[K]>(key: K, value: V):
+        ObjectValidator<Root, T & { [Key in keyof Pick<T, K>]: V }>;
+};
+
+type ArrayValidator<Root, T> = ObjectValidator<Root, T> & {
     validate(validator: ValidateFn<T[]>, message?: string): void;
 
     forEach(fn: (validator: NestedValidator<Root, T>) => void): void;
@@ -40,7 +44,6 @@ type ArrayValidator<Root, T> = CommonValidator<T> & ObjectValidator<Root, T> & {
 
 interface Condition {
     fn: (value: any, root: any) => boolean;
-    state: State<any>;
     path: Path;
 }
 
@@ -49,16 +52,17 @@ interface Validator {
     path: Path;
     message?: string;
     required?: boolean;
-    condition?: Condition;
+    conditions: Condition[];
 }
-
-type ReturnType<Root, T> = ObjectValidator<Root, T> | ArrayValidator<Root, T> | SingleValidator<T>;
 
 class ValidatorInstance<T> {
     validators: Validator[] = [];
 
+    constructor(private root: State<StateValueAtRoot>) {
+    }
+
     isRequired(state: State<T>) {
-        return this.matchValidators(state).some(s => !!s.validator.required);
+        return this.validators.filter(v => v.required).some(v => this.pathToTargets(v.path, state).length > 0);
     }
 
     valid(state: State<T>) {
@@ -66,149 +70,134 @@ class ValidatorInstance<T> {
     }
 
     errors(state: State<T>) {
-        const validators = this.matchValidators(state);
+        const errors: string[] = [];
 
-        let errors: string[] = [];
+        for (const validator of this.validators) {
+            const targets = this.pathToTargets(validator.path, state);
 
-        for (const { paths, validator } of validators) {
-            if (paths.length && isArrayState(state)) {
-                state.forEach((item, index) => {
-                    if (!this.conditionalValid(validator, item)) {
-                        return;
+            for (const target of targets) {
+                let valid = true;
+
+                // use traditional loop to ensure all subscriptions occur in when functions
+                for (const conditions of validator.conditions) {
+                    if (!this.conditionalValid(validator.path, conditions, target)) {
+                        valid = false;
                     }
+                }
 
-                    errors = [...errors, ...this.validNested(paths, item, validator)];
-                });
-            } else {
-                if (!this.conditionalValid(validator, state)) {
+                if (!valid) {
                     continue;
                 }
 
-                errors = [...errors, ...this.validNested(paths, state, validator)];
+                if (!validator.fn(target.state.get())) {
+                    errors.push(validator.message || 'This field is not valid.');
+                }
             }
         }
 
         return errors;
     }
 
-    private conditionalValid(validator: Validator, state: State<any>): boolean {
-        if (!validator.condition) {
-            return true;
-        }
+    private pathToTargets(path: Path, state: State<any>, parent?: NestedState): NestedState[] {
+        const target = { state, parent };
 
         if (isArrayState(state)) {
-            return state.every((t, index) => this.conditionalValid(validator, t));
-        }
+            const items: NestedState[] = [];
 
-        if (state.path.filter(p => typeof p !== 'number').length > validator.condition.path.length) {
-            // the property getting validated is too deep, need to use validator state
-            return this.conditionalValid(validator, validator.condition.state);
-        }
+            state.forEach((item, index) => {
+                const nested = this.pathToTargets(path, item, target);
 
-        // always skip first, they are the same as target state
-        const statePaths = state.path.slice(0);
-        const conditionPath = validator.condition.path.slice(0);
-
-        // normalize paths
-        while (statePaths.length) {
-            if (typeof statePaths[0] === 'string') {
-                if (!conditionPath.length) {
-                    break;
+                if (nested.length > 1) {
+                    throw new Error('nested arrays not supported.');
                 }
 
-                if (statePaths[0] === conditionPath[0]) {
-                    conditionPath.shift();
+                if (nested.length === 1) {
+                    items.push({ state: nested[0].state, parent: nested[0].parent });
+                }
+            });
+
+            return items;
+        }
+
+        const statePaths = state.path.slice(0);
+        const requestedPaths = path.slice(0);
+
+        while (requestedPaths.length) {
+            if (!statePaths.length) {
+                const next = requestedPaths.shift();
+
+                if (!next) {
+                    throw new Error('should not happen');
+                }
+
+                return this.pathToTargets(path, state.nested(next), target);
+            }
+
+            if (typeof statePaths[0] === 'string') {
+                if (statePaths[0] === requestedPaths[0]) {
+                    requestedPaths.shift();
                     statePaths.shift();
 
                     continue;
                 }
 
-                // paths do not match, ignore conditional validator
-                return true;
+                // paths do not match, skip
+                return [];
             }
 
-            // assume it is an index and continue
             statePaths.shift();
         }
 
-        if (conditionPath.length > 1) {
-            return this.conditionalValid(validator, state.nested(conditionPath[0]));
-        }
-
-        let target = state;
-
-        if (conditionPath.length === 1) {
-            target = state.nested(conditionPath[0]);
-
-            if (isArrayState(target)) {
-                return target.every((t, index) => this.conditionalValid(validator, t));
-            }
-        }
-
-        return validator.condition.fn(target.get(), validator.condition.state.get());
+        return [target];
     }
 
-    private matchValidators(state: State<any>) {
-        return this.validators.map(validator => {
-            const paths = [...validator.path];
+    private conditionalValid(path: Path, condition: Condition, nested: NestedState): boolean {
+        if (isArrayState(nested.state)) {
+            return nested.state.every((t) => this.conditionalValid(path, condition, { state: t, parent: nested }));
+        }
 
-            let match = true;
+        let conditionRoot;
+        let target;
 
-            for (const path of state.path) {
-                if (typeof path === 'string') {
-                    if (paths.length === 0) {
-                        break;
-                    }
+        if (!nested.parent) {
+            conditionRoot = this.pathToTargets(condition.path, this.root)[0];
 
-                    if (paths.shift() !== path) {
-                        match = false;
-                        break;
-                    }
-                } else if (typeof path === 'number') {
-                    if (paths.length === 0) {
-                        match = false;
+            target = this.root;
 
-                        break;
-                    }
+            const paths = nested.state.path.slice(0);
+            let stop = conditionRoot.state.path.length;
+
+            if (isArrayState(conditionRoot.state)) {
+                stop += 1;
+            }
+
+            while (target.path.length < stop) {
+                const next = paths.shift();
+
+                if (next !== undefined) {
+                    target = target.nested(next);
+                }
+            }
+        } else {
+            target = nested.parent;
+            conditionRoot = nested.parent;
+
+            while (conditionRoot.state.path.toString() !== condition.path.toString()) {
+                if (conditionRoot.parent) {
+                    conditionRoot = conditionRoot.parent;
                 }
             }
 
-            return {
-                paths,
-                match,
-                validator,
-            };
-        }).filter(v => !!v.match);
-    }
-
-    private validNested(paths: Path, state: State<any>, validator: Validator): string[] {
-        if (isArrayState(state)) {
-            return state.map((item, index) => {
-                return this.validNested(paths, state[index], validator);
-            }).flat();
-        }
-
-        if (paths.length) {
-            // drill down any unmatched paths
-            const nested = paths.slice(0);
-            const path = nested.shift();
-
-            if (!path) {
-                throw new Error('Should not happen.');
+            while (target.state.path.filter(f => typeof f !== 'number').toString() !== condition.path.toString()) {
+                if (target.parent) {
+                    target = target.parent;
+                }
             }
 
-            return this.validNested(nested, state.nested(path), validator);
+            target = target.state;
         }
 
-        if (isPrimitiveState(state)) {
-            if (!validator.fn(state.get())) {
-                return [validator.message || 'This field is not valid.'];
-            }
-        } else if (!validator.fn(state.get())) {
-            return [validator.message || 'This field is not valid.'];
-        }
-
-        return [];
+        return condition.fn(target, conditionRoot.state);
     }
 }
 
@@ -228,68 +217,44 @@ function buildProxy(
     instance: ValidatorInstance<any>,
     path: Path,
     state: State<any>,
-    condition?: Condition,
+    conditions: Condition[],
 ): any {
     return new Proxy({}, {
         apply(t: (fieldValidator: ValidateFn<any>) => void, thisArg: any, argArray?: any): any {
             t.apply(thisArg, argArray);
         },
-        get(_: any, nestedProp: PropertyKey, receiver: any) {
-            if (nestedProp === 'when') {
-                return (when: ValidateFn<any>) => {
-                    condition = {
-                        fn: when,
-                        state,
-                        path,
-                    };
+        get(_: any, nestedProp: PropertyKey) {
+            const cleanPath = path.filter(p => typeof p !== 'number');
 
-                    return receiver;
-                };
+            if (nestedProp === 'whenType') {
+                return (key: any, value: any) => buildProxy(instance, path, state, [
+                    ...conditions,
+                    {
+                        fn: (s) => s[key].get() === value,
+                        path: cleanPath,
+                    },
+                ]);
             }
 
-            if (nestedProp === 'isRequired') {
-                return () => instance.isRequired(state);
+            if (nestedProp === 'when') {
+                return (when: ValidateFn<any>) => buildProxy(instance, path, state, [
+                    ...conditions,
+                    {
+                        fn: when,
+                        path: cleanPath,
+                    },
+                ]);
             }
 
             if (nestedProp === 'required') {
                 return (message?: string) => {
                     instance.validators.push({
                         fn: (value => Array.isArray(value) ? value.length > 0 : !!value),
-                        path,
+                        path: cleanPath,
                         required: true,
                         message: message || 'This field is required',
-                        condition,
+                        conditions,
                     });
-                };
-            }
-
-            if (nestedProp === 'errors') {
-                return (fields?: any[]) => {
-                    if (fields === undefined) {
-                        return instance.errors(state);
-                    }
-
-                    let errors: string[] = [];
-
-                    for (const field of fields) {
-                        errors = [...errors, ...instance.errors(state.nested(field))];
-                    }
-
-                    return errors;
-                };
-            }
-
-            if (nestedProp === 'valid') {
-                return (fields?: any[]) => {
-                    if (fields === undefined) {
-                        return instance.valid(state);
-                    }
-
-                    for (const field of fields) {
-                        return instance.valid(state.nested(field));
-                    }
-
-                    return true;
                 };
             }
 
@@ -297,49 +262,69 @@ function buildProxy(
                 return (nestedValidator: ValidateFn<any>, message?: string) => {
                     instance.validators.push({
                         fn: nestedValidator,
-                        path,
+                        path: cleanPath,
                         message,
-                        condition,
+                        conditions,
                     });
                 };
             }
 
             if (nestedProp === 'forEach') {
                 return (fn: (validator: any) => void) => {
-                    fn(buildProxy(instance, path, state));
+                    fn(buildProxy(instance, path, state, conditions.slice(0)));
                 };
             }
 
-            // user is chaining down properties
-            return buildProxy(instance, [...path, nestedProp], state, condition);
+            return buildProxy(instance, [...path, nestedProp], state, conditions.slice(0));
         },
     });
 }
 
-export function Validation(): Plugin;
-export function Validation(input: State<string>): SingleValidator<string>;
-export function Validation(input: State<number>): SingleValidator<number>;
-export function Validation<T>(input: State<T[]>): ArrayValidator<T[], T>;
-export function Validation<T>(input: State<T>): ObjectValidator<T, T>;
-export function Validation<T>(input?: State<T>): Plugin | ReturnType<T, T> {
-    if (input === undefined) {
-        return {
-            id: ValidationId,
-            init: () => {
-                return new ValidatorInstance() as PluginCallbacks;
-            },
-        };
-    }
-
+export function Validation<T>(input: State<T>) {
     const [instance] = input.attach(ValidationId);
 
     if (instance instanceof Error) {
-        throw new Error(`Forgot to run state.attach(Validation())`);
+        throw new Error(`Forgot to run ValidationAttach()`);
     }
 
     if (!(instance instanceof ValidatorInstance)) {
         throw new Error('Expected plugin to be of ValidatorInstance');
     }
 
-    return buildProxy(instance, input.path, input);
+    return {
+        valid(fields?: any[]): boolean {
+            return this.errors(fields).length === 0;
+        },
+        required(): boolean {
+            return instance.isRequired(input);
+        },
+        errors(fields?: any[]): string[] {
+            if (fields === undefined) {
+                return instance.errors(input);
+            }
+
+            let errors: string[] = [];
+
+            for (const field of fields) {
+                errors = [...errors, ...instance.errors(input.nested(field))];
+            }
+
+            return errors;
+        },
+    };
+}
+
+export function ValidationAttach<T>(state: State<T>, config: ((validator: NestedValidator<T, T>) => void)) {
+    state.attach(() => ({
+        id: ValidationId,
+        init: (root) => {
+            const instance = new ValidatorInstance(root);
+
+            const api = buildProxy(instance, state.path, state, []);
+
+            config(api);
+
+            return instance as PluginCallbacks;
+        },
+    }));
 }


### PR DESCRIPTION
Potential implementation direction as a solution to #94 and maybe introduce a new Fluent API abstraction.

Problem:

- Need a way to support running validation in child components yet maintaining isValid() state in a parent component. Example, multiple tabs with a "error badge" if any of the state displayed within the tab is invalid (and doing so in a way that doesn't cause a full re-render).
- Need a way to validate data within an array whose length may change at any time.

Proposed API syntax:

```typescript
    ValidationAttach(state, (validator) => {
      // conditional validation
      const enabled = validator.notifications.when(n => n.enabled.get());
      enabled.message.required();

      // union type support (graphql example), conditional reuse
      enabled.whenType('__typename', 'NotificationConfigEmail').subject.required();
      enabled.whenType('__typename', 'NotificationConfigSlack').channel.required();

      // nested array path support
      validator.roles.name.validate(name => name && name.length > 0);

      // inject any other parts of the state into conditionals
      validator.properties.conditions.when((c, properties) => {
        if (!c.propertyId.get()) {
          return false;
        }

        return properties.some(p => p.id.get() === c.propertyId.get() && p.fieldType.get() === FieldType.SELECT);
      }, validator.properties).valueId.required();
    });

    // validate entire state
    Validation(state).valid();
    
    // validate portion of state (eg: navigation/tabs)
    Validation(state.roles).valid();

    // validation multiple portions (eg: multiple fields on same tab)
    Validation(state).valid(['roles','notifications']);

    // downstream component can check if it is required or valid
    const validation = Validation(state.field);

    const form = <Input error={!validation.valid()) value={state.field.get()} required={validation.required()} />
```