### PR TITLE
Fixed `process is not defined` issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -678,8 +678,8 @@ export function DevTools<S>(state: State<S>): DevToolsExtensions {
 /// INTERNAL SYMBOLS (LIBRARY IMPLEMENTATION)
 ///
 
-const isDevelopmentMode = process !== undefined && process !== null && typeof process === 'object' &&
-    process.env !== undefined && process.env !== null && typeof process.env === 'object' &&
+const isDevelopmentMode = typeof process === 'object' && 
+    typeof process.env === 'object' &&
     process.env.NODE_ENV === 'development'
 
 const self = Symbol('self')


### PR DESCRIPTION
Fixed `process is not defined` issue when running in an environment where `process` is not set.

![image](https://user-images.githubusercontent.com/57860196/124361427-8487d480-dc2f-11eb-9f2f-98af2ba884fd.png)
