### PR TITLE
Add dep checks to useHookEffect

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -1911,8 +1911,9 @@ const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? React.useLayou
 
 let originUseEffect: (effect: React.EffectCallback, deps?: React.DependencyList) => void;
 function useHookEffect(effect: React.EffectCallback, deps?: React.DependencyList) {
-    for (const i of deps || []) {
-        let state = (i as any)[self] as StateMethodsImpl<StateValueAtPath> | undefined
+    for (const dep of deps || []) {
+        if (!dep || typeof dep !== 'object') continue
+        let state = (dep as any)[self] as StateMethodsImpl<StateValueAtPath> | undefined
         if (state) {
             state.reconnect()
         }


### PR DESCRIPTION
Solves the following issue:

```ts
function useHookEffect(effect: React.EffectCallback, deps?: React.DependencyList) {
    for (const i of deps || []) {
        let state = (i as any)[self] as StateMethodsImpl<StateValueAtPath> | undefined 
                       // ^ Uncaught TypeError: Cannot read properties of undefined (reading 'Symbol(self)')
        if (state) {
            state.reconnect()
        }
    }
    return originUseEffect(effect, deps)
}
```