### PR TITLE
fix(localstored): mark "engine"-option as optional

### DIFF
--- a/plugins/localstored/src/localstorage.ts
+++ b/plugins/localstored/src/localstorage.ts
@@ -10,7 +10,7 @@ export interface LocalStored { }
 
 export function localstored<S, E>(options?: {
     key?: string,
-    engine: StoreEngine,
+    engine?: StoreEngine,
     initializer: () => Promise<S>
 }): ExtensionFactory<S, E, LocalStored> {
     return () => {


### PR DESCRIPTION
The documentation and code mark the "engine"-prop as optional. However, the TypeScript type enforces it to be required, therefore any consumer who tries to omit this prop and use the default built-in engine gets a TypeScript error.

This change updates the argument-type of localstored, such that the "engine"-option becomes optional. Which allows a consumer to use the default build-in LocalStorage-based engine.

Old behaviour:
![image](https://user-images.githubusercontent.com/15435678/210091858-f208de0c-0628-41d1-a81c-a4f4c2708ef0.png)

Documentation examples show usage of this plugin without explicitly setting an implementation for the engine:
https://github.com/avkonst/hookstate/blob/master/docs/index/src/examples/plugin-localstored.tsx