### PR TITLE
Fix localstored initializer to be optional

### DIFF
--- a/plugins/localstored/src/localstorage.ts
+++ b/plugins/localstored/src/localstorage.ts
@@ -11,7 +11,7 @@ export interface LocalStored { }
 export function localstored<S, E>(options?: {
     key?: string,
     engine?: StoreEngine,
-    initializer: () => Promise<S>
+    initializer?: () => Promise<S>
 }): ExtensionFactory<S, E, LocalStored> {
     return () => {
         let key: string;


### PR DESCRIPTION
ref https://github.com/avkonst/hookstate/pull/372 https://github.com/avkonst/hookstate/issues/370

Hello, v4.0.1 still raise type error.

<img width="676" alt="スクリーンショット 2023-04-12 21 42 02" src="https://user-images.githubusercontent.com/56591/231471886-ebf484d3-1cec-4ebc-86ae-5ab45a4ec5ca.png">

This PR change initializer to be optional.

After apply this patch, type error will fixed
<img width="634" alt="スクリーンショット 2023-04-12 22 19 30" src="https://user-images.githubusercontent.com/56591/231472249-a8cd47ba-cf9c-4447-9cd2-90139865ec01.png">
