### PR TITLE
fix type inference for nullable state values

### DIFF
--- a/core/src/__tests__/Typing.tsx
+++ b/core/src/__tests__/Typing.tsx
@@ -8,7 +8,7 @@ test('check assignability on typescript level', async () => {
         let a = hookstate<{ a: string, b?: string }>({ a: 'a', b: 'b' })
         let b: State<{ a: string }> = a;
     }
-    
+
     {
         //assign state with extension method to a state without
         interface Inf {
@@ -20,5 +20,36 @@ test('check assignability on typescript level', async () => {
             })
         }))
         let b: State<{ a: string }> = a;
+    }
+
+    {
+        // array inference
+        let a = hookstate<{ a: string }[]>([]);
+        let b: State<{ a: string }> = a[0];
+    }
+
+    {
+        // nullable array inference
+        let a = hookstate<{ a: string }[] | null>(null);
+        let b: State<{ a: string }> | undefined = a[0];
+    }
+
+    {
+        // object inference
+        let a = hookstate<{ a: string }>({ a: 'a' });
+        let b: State<string> = a.a;
+    }
+
+    {
+        // nullable object inference
+        let a = hookstate<{ a: string } | null>(null);
+        let b: State<string> | undefined = a.a;
+    }
+
+    {
+        // null inference
+        let a = hookstate<null>(null);
+        // if this is not an error, inference works correctly
+        let b: 'a' extends keyof typeof a ? never : typeof a = a;
     }
 });

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -291,9 +291,9 @@ export type State<S, E = {}> = __State<S, E> & StateMethods<S, E> & E & (
     S extends ReadonlyArray<infer U> ? ReadonlyArray<State<U, E>> :
     Omit<
         S extends {}
-            ? { readonly [K in keyof Required<S>]: S[K] extends Function ? never : State<S[K], E> }
+            ? { readonly [K in keyof Required<S>]: State<S[K], E> }
             : { readonly [K in keyof any]: undefined },
-        keyof StateMethods<S, E> | keyof E
+        keyof StateMethods<S, E> | InferKeysOfType<S, Function> | keyof E
     >
 );
 

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -287,6 +287,7 @@ export type InferReturnType<V> = V extends (...args: any) => (infer R) ? InferRe
  * [Learn more about nested states...](https://hookstate.js.org/docs/nested-state)
  */
 export type State<S, E = {}> = __State<S, E> & StateMethods<S, E> & E & Omit<
+    [S] extends [Exclude<S, {}>] ? {} :
     S extends ReadonlyArray<infer U> ? ReadonlyArray<State<U, E>> :
     S extends {} ? { readonly [K in keyof Required<S>]: State<S[K], E> } :
     { readonly [K in keyof any]: undefined },

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -286,13 +286,16 @@ export type InferReturnType<V> = V extends (...args: any) => (infer R) ? InferRe
  * [Learn more about local states...](https://hookstate.js.org/docs/local-state)
  * [Learn more about nested states...](https://hookstate.js.org/docs/nested-state)
  */
-export type State<S, E = {}> = __State<S, E> & StateMethods<S, E> & E & Omit<
+export type State<S, E = {}> = __State<S, E> & StateMethods<S, E> & E & (
     [S] extends [Exclude<S, {}>] ? {} :
     S extends ReadonlyArray<infer U> ? ReadonlyArray<State<U, E>> :
-    S extends {} ? { readonly [K in keyof Required<S>]: State<S[K], E> } :
-    { readonly [K in keyof any]: undefined },
-    keyof StateMethods<S, E> | InferKeysOfType<S, Function> | keyof E
->;
+    Omit<
+        S extends {}
+            ? { readonly [K in keyof Required<S>]: S[K] extends Function ? never : State<S[K], E> }
+            : { readonly [K in keyof any]: undefined },
+        keyof StateMethods<S, E> | keyof E
+    >
+);
 
 /**
  * For extension developers only.

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -286,13 +286,12 @@ export type InferReturnType<V> = V extends (...args: any) => (infer R) ? InferRe
  * [Learn more about local states...](https://hookstate.js.org/docs/local-state)
  * [Learn more about nested states...](https://hookstate.js.org/docs/nested-state)
  */
-export type State<S, E = {}> = __State<S, E> & StateMethods<S, E> & E & (
-    S extends ReadonlyArray<(infer U)> ? ReadonlyArray<State<U, E>> :
-    S extends object ? Omit<
-        { readonly [K in keyof Required<S>]: State<S[K], E>; },
-        keyof StateMethods<S, E> | InferKeysOfType<S, Function> | keyof E
-    > : {}
-);
+export type State<S, E = {}> = __State<S, E> & StateMethods<S, E> & E & Omit<
+    S extends ReadonlyArray<infer U> ? ReadonlyArray<State<U, E>> :
+    S extends {} ? { readonly [K in keyof Required<S>]: State<S[K], E> } :
+    { readonly [K in keyof any]: undefined },
+    keyof StateMethods<S, E> | InferKeysOfType<S, Function> | keyof E
+>;
 
 /**
  * For extension developers only.


### PR DESCRIPTION
if the type of `state` is `State<{ x: string } | null>`, then `state.x` will not be accepted by the type checker, because `x` is not inferred as a property of `state`, even though the true type of `state.x` should be `State<string> | undefined`. (`undefined` when `state.value === null`)

previously this code threw a type error:

```ts
import { useHookstate } from '@hookstate/core'

const ugh = () => {
  const state = useHookstate<{ x: string } | null>(null)
  const x = state.x // ts(2339) Property 'x' does not exist on type 'State<{ x: string; } | null, {}>'.
}
```
```
Property 'x' does not exist on type 'State<{ x: string; } | null, {}>'.
  Property 'x' does not exist on type '__State<{ x: string; } | null, {}> & StateMethods<{ x: string; } | null, {}>'.
```

now it does not and the type is inferred correctly:

```ts
const x: State<string, {}> | undefined
```