### PR TITLE
fix devtools 110 error while using functions in state

### DIFF
--- a/plugins/devtools/package.json
+++ b/plugins/devtools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hookstate/devtools",
-    "version": "4.0.2",
+    "version": "4.0.3",
     "description": "Development tools plugin for @hookstate/core.",
     "license": "MIT",
     "author": {

--- a/plugins/devtools/src/devtools.ts
+++ b/plugins/devtools/src/devtools.ts
@@ -61,7 +61,7 @@ function createReduxDevToolsLogger(
             if (stateAtRoot.promised || stateAtRoot.error) {
                 return none
             }
-            return stateAtRoot.value
+            return stateAtRoot.get({noproxy: true})
         },
         devToolsEnhancer({
             name: `${window.location.hostname}: ${assignedId}`,


### PR DESCRIPTION
If a function is present in the state, devtools will return error 110 both during initialization and when trying to set something